### PR TITLE
Refactor BaseCard.vue and NotFoundView.vue components

### DIFF
--- a/src/modules/shared/components/BaseCard.vue
+++ b/src/modules/shared/components/BaseCard.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 interface Props {
-  loading: boolean
+  loading?: boolean
   deleted?: boolean
 }
 withDefaults(defineProps<Props>(), {
-  deleted: false
+  deleted: false,
+  loading: false
 })
 </script>
 

--- a/src/modules/shared/views/NotFoundView.vue
+++ b/src/modules/shared/views/NotFoundView.vue
@@ -6,24 +6,22 @@ import BaseCard from '../components/BaseCard.vue'
 <template>
   <!-- component -->
   <BaseCard class="sm:w-full md:w-1/2 xl:w-2/5 m-auto max-w-[30rem]">
-    <template #content>
-      <section class="flex flex-col justify-center items-center">
-        <p class="text-6xl md:text-7xl lg:text-9xl font-bold tracking-wider">404</p>
-        <p
-          class="text-2xl md:text-3xl lg:text-5xl font-bold tracking-wider mt-4 text-muted-color-emphasis"
-        >
-          No encontrado
-        </p>
-        <p class="mt-4 pb-4 border-b-2 text-center text-muted-color">
-          La página que buscas no existe o ha sido movida.
-        </p>
+    <section class="flex flex-col justify-center items-center">
+      <p class="text-6xl md:text-7xl lg:text-9xl font-bold tracking-wider">404</p>
+      <p
+        class="text-2xl md:text-3xl lg:text-5xl font-bold tracking-wider mt-4 text-muted-color-emphasis"
+      >
+        No encontrado
+      </p>
+      <p class="mt-4 pb-4 border-b-2 text-center text-muted-color">
+        La página que buscas no existe o ha sido movida.
+      </p>
 
-        <CustomButton
-          class="mt-6"
-          label="Regresar al inicio"
-          @click="$router.replace({ name: 'home' })"
-        />
-      </section>
-    </template>
+      <CustomButton
+        class="mt-6"
+        label="Regresar al inicio"
+        @click="$router.replace({ name: 'home' })"
+      />
+    </section>
   </BaseCard>
 </template>


### PR DESCRIPTION
This pull request includes changes to the `BaseCard` component and the `NotFoundView` view to improve the handling of optional props and to clean up the template structure.

Changes to `BaseCard` component:

* [`src/modules/shared/components/BaseCard.vue`](diffhunk://#diff-0d1cc37c8eb7640fdcdc8b6ffa33561545c1db40fcc0c552762d917750549a93L3-R8): Made the `loading` prop optional and provided a default value of `false`.

Changes to `NotFoundView` view:

* [`src/modules/shared/views/NotFoundView.vue`](diffhunk://#diff-4c546f3c3156dc831770663b1c55b49df567ff451a94b3888138db2b5f2c8b97L9): Removed unnecessary `template` tags around the content of the `BaseCard` component. [[1]](diffhunk://#diff-4c546f3c3156dc831770663b1c55b49df567ff451a94b3888138db2b5f2c8b97L9) [[2]](diffhunk://#diff-4c546f3c3156dc831770663b1c55b49df567ff451a94b3888138db2b5f2c8b97L27)